### PR TITLE
Store monster HD in mon-info

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -367,10 +367,7 @@ static void _describe_book(const spellbook_contents &book,
     const bool doublecolumn = _list_spells_doublecolumn(source_item);
 
     bool first_line_element = true;
-    // FIXME: this HD is wrong in some cases
-    // (draining, malmutation, levelling up)
-    const int hd = (mon_owner == NULL ? 0 :
-                                        mons_class_hit_dice(mon_owner->type));
+    const int hd = mon_owner == NULL ? 0 : mon_owner->hd;
     for (auto spell : book.spells)
     {
         description.cprintf(" ");

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2920,9 +2920,7 @@ static int _get_spell_description(const spell_type spell,
 
     if (mon_owner)
     {
-        // FIXME: this HD is wrong in some cases
-        // (draining, malmutation, levelling up)
-        const int hd = mons_class_hit_dice(mon_owner->type);
+        const int hd = mon_owner->hd;
         const int range = mons_spell_range(spell, hd);
         description += "\nRange : "
                        + range_string(range, range, mons_char(mon_owner->type))

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -370,6 +370,7 @@ monster_info::monster_info(monster_type p_type, monster_type p_base_type)
 
     mintel = mons_class_intel(type);
 
+    hd = mons_class_hit_dice(type);
     ac = get_mons_class_ac(type);
     ev = base_ev = get_mons_class_ev(type);
     mresists = get_mons_class_resists(type);
@@ -409,6 +410,7 @@ monster_info::monster_info(monster_type p_type, monster_type p_base_type)
         i_ghost.best_skill = SK_FIGHTING;
         i_ghost.best_skill_rank = 2;
         i_ghost.xl_rank = 3;
+        hd = ghost_rank_to_level(i_ghost.xl_rank);
         i_ghost.ac = 5;
         i_ghost.damage = 5;
     }
@@ -592,6 +594,7 @@ monster_info::monster_info(const monster* m, int milev)
     holi = m->holiness();
 
     mintel = mons_intel(m);
+    hd = m->get_hit_dice();
     ac = m->armour_class(false);
     ev = m->evasion(EV_IGNORE_UNIDED);
     base_ev = m->base_evasion();
@@ -1714,10 +1717,6 @@ int monster_info::res_magic() const
     int mr = (get_monster_data(type))->resist_magic;
     if (mr == MAG_IMMUNE)
         return MAG_IMMUNE;
-
-    const int hd = mons_is_pghost(type) ? ghost_rank_to_level(i_ghost.xl_rank)
-            : type == MONS_MUTANT_BEAST ? props[MUTANT_BEAST_TIER].get_short()
-                                        : mons_class_hit_dice(type);
 
     // Negative values get multiplied with monster hit dice.
     if (mr < 0)

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -171,6 +171,7 @@ struct monster_info_base
     string quote;
     mon_holy_type holi;
     mon_intel_type mintel;
+    int hd;
     int ac;
     int ev;
     int base_ev;

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -171,6 +171,7 @@ enum tag_minor_version
     TAG_MINOR_SAVED_PIETY,         // allowed good-god piety to survive through an atheist period
     TAG_MINOR_GHOST_SINV,          // marshall ghost_demon sinv
     TAG_MINOR_ID_STATES,           // turn item_type_id_state_type into a bool
+    TAG_MINOR_MON_HD_INFO,         // store player-known monster HD info
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -4652,6 +4652,7 @@ void marshallMonsterInfo(writer &th, const monster_info& mi)
     marshallString(th, mi.quote);
     marshallUnsigned(th, mi.holi);
     marshallUnsigned(th, mi.mintel);
+    marshallUnsigned(th, mi.hd);
     marshallUnsigned(th, mi.ac);
     marshallUnsigned(th, mi.ev);
     marshallUnsigned(th, mi.base_ev);
@@ -4744,6 +4745,15 @@ void unmarshallMonsterInfo(reader &th, monster_info& mi)
     mi.quote = unmarshallString(th);
 
 #if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_MON_HD_INFO)
+    {
+#endif
+        unmarshallUnsigned(th, mi.hd);
+#if TAG_MAJOR_VERSION == 34
+    }
+    else
+        mi.hd = mons_class_hit_dice(mi.type);
+
     if (th.getMinorVersion() >= TAG_MINOR_DISPLAY_MON_AC_EV)
     {
 #endif


### PR DESCRIPTION
This allows correct display of MR for monsters which have MR
varying by HD (pan lords, etc).

It'll also be useful for something else, shortly.
